### PR TITLE
Templates: add FilAr PLA, PLA Mate and PETG filaments

### DIFF
--- a/Templates/2.0.4.ini
+++ b/Templates/2.0.4.ini
@@ -1,0 +1,2672 @@
+# Generic filament profile templates
+
+[vendor]
+repo_id = non-prusa-fff
+name = Templates
+config_version = 2.0.4
+config_update_url = https://files.prusa3d.com/wp-content/uploads/repository/PrusaSlicer-settings-master/live/Templates/
+templates_profile = 1
+
+## Generic filament profiles
+
+[filament:*common*]
+cooling = 1
+compatible_printers = 
+compatible_printers_condition = printer_notes!~/.*NO_TEMPLATES.*/ and printer_notes!~/.*PRINTER_VENDOR_TRILAB.*/ and printer_notes!~/.*PRINTER_MODEL_MK4IS.*/ and ! (printer_notes=~/.*PRINTER_VENDOR_PRUSA3D.*/ and num_extruders>1)
+end_filament_gcode = "; Filament-specific end gcode"
+extrusion_multiplier = 1
+filament_loading_speed = 14
+filament_loading_speed_start = 19
+filament_unloading_speed = 20
+filament_unloading_speed_start = 100
+filament_toolchange_delay = 0
+filament_cooling_moves = 1
+filament_cooling_initial_speed = 3
+filament_cooling_final_speed = 2
+filament_load_time = 0
+filament_unload_time = 0
+filament_ramming_parameters = "130 120 2.70968 2.93548 3.32258 3.83871 4.58065 5.54839 6.51613 7.35484 7.93548 8.16129| 0.05 2.66451 0.45 3.05805 0.95 4.05807 1.45 5.97742 1.95 7.69999 2.45 8.1936 2.95 11.342 3.45 11.4065 3.95 7.6 4.45 7.6 4.95 7.6"
+filament_minimal_purge_on_wipe_tower = 0
+filament_cost = 0
+filament_density = 0
+filament_diameter = 1.75
+filament_notes = ""
+filament_settings_id = ""
+filament_soluble = 0
+min_print_speed = 10
+slowdown_below_layer_time = 10
+start_filament_gcode = 
+
+[filament:*PLA*]
+inherits = *common*
+bed_temperature = 60
+bridge_fan_speed = 100
+disable_fan_first_layers = 1
+full_fan_speed_layer = 3
+fan_always_on = 1
+fan_below_layer_time = 100
+filament_colour = #FF8000
+filament_max_volumetric_speed = 0
+filament_type = PLA
+first_layer_bed_temperature = 60
+first_layer_temperature = 215
+max_fan_speed = 100
+min_fan_speed = 100
+temperature = 210
+
+[filament:*PET*]
+inherits = *common*
+bed_temperature = 90
+bridge_fan_speed = 50
+disable_fan_first_layers = 3
+full_fan_speed_layer = 5
+fan_always_on = 1
+fan_below_layer_time = 20
+filament_colour = #FF8000
+filament_max_volumetric_speed = 0
+filament_type = PETG
+first_layer_bed_temperature = 85
+first_layer_temperature = 230
+max_fan_speed = 50
+min_fan_speed = 30
+temperature = 240
+
+[filament:*ABS*]
+inherits = *common*
+bed_temperature = 100
+bridge_fan_speed = 25
+cooling = 0
+disable_fan_first_layers = 3
+fan_always_on = 0
+fan_below_layer_time = 20
+filament_colour = #FFF2EC
+filament_max_volumetric_speed = 0
+filament_ramming_parameters = "120 100 5.70968 6.03226 7 8.25806 9 9.19355 9.3871 9.77419 10.129 10.3226 10.4516 10.5161| 0.05 5.69677 0.45 6.15484 0.95 8.76774 1.45 9.20323 1.95 9.95806 2.45 10.3871 2.95 10.5677 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+filament_type = ABS
+first_layer_bed_temperature = 100
+first_layer_temperature = 255
+max_fan_speed = 30
+min_fan_speed = 20
+temperature = 255
+
+[filament:*ABSC*]
+inherits = *common*
+bed_temperature = 100
+bridge_fan_speed = 25
+cooling = 1
+disable_fan_first_layers = 4
+fan_always_on = 0
+fan_below_layer_time = 30
+slowdown_below_layer_time = 20
+filament_colour = #FFF2EC
+filament_max_volumetric_speed = 0
+filament_ramming_parameters = "120 100 5.70968 6.03226 7 8.25806 9 9.19355 9.3871 9.77419 10.129 10.3226 10.4516 10.5161| 0.05 5.69677 0.45 6.15484 0.95 8.76774 1.45 9.20323 1.95 9.95806 2.45 10.3871 2.95 10.5677 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+filament_type = ABS
+first_layer_bed_temperature = 100
+first_layer_temperature = 255
+max_fan_speed = 15
+min_fan_speed = 15
+min_print_speed = 15
+temperature = 255
+
+[filament:*FLEX*]
+inherits = *common*
+bed_temperature = 50
+bridge_fan_speed = 80
+cooling = 0
+disable_fan_first_layers = 3
+extrusion_multiplier = 1.15
+fan_always_on = 0
+fan_below_layer_time = 100
+filament_colour = #008000
+filament_max_volumetric_speed = 0
+filament_type = FLEX
+first_layer_bed_temperature = 50
+first_layer_temperature = 240
+max_fan_speed = 90
+min_fan_speed = 70
+temperature = 240
+
+[filament:ColorFabb bronzeFill]
+inherits = *PLA*
+filament_vendor = ColorFabb
+extrusion_multiplier = 1.12
+filament_cost = 80.65
+filament_density = 3.9
+filament_spool_weight = 236
+filament_colour = #804040
+
+[filament:ColorFabb steelFill]
+inherits = *PLA*
+filament_vendor = ColorFabb
+extrusion_multiplier = 1.1
+filament_cost = 80.65
+filament_density = 3.13
+filament_spool_weight = 236
+filament_colour = #808080
+
+[filament:ColorFabb copperFill]
+inherits = *PLA*
+filament_vendor = ColorFabb
+extrusion_multiplier = 1.1
+filament_cost = 80.65
+filament_density = 3.9
+filament_spool_weight = 236
+filament_colour = #82603E
+
+[filament:ColorFabb HT]
+inherits = *PET*
+filament_vendor = ColorFabb
+bed_temperature = 100
+bridge_fan_speed = 30
+cooling = 1
+disable_fan_first_layers = 3
+fan_always_on = 0
+fan_below_layer_time = 10
+filament_cost = 65.66
+filament_density = 1.18
+filament_spool_weight = 236
+first_layer_bed_temperature = 100
+first_layer_temperature = 270
+max_fan_speed = 20
+min_fan_speed = 10
+temperature = 270
+
+[filament:ColorFabb PLA-PHA]
+inherits = *PLA*
+filament_vendor = ColorFabb
+filament_cost = 54.84
+filament_density = 1.24
+filament_spool_weight = 236
+
+[filament:ColorFabb woodFill]
+inherits = *PLA*
+filament_vendor = ColorFabb
+extrusion_multiplier = 1.1
+filament_cost = 78.63
+filament_density = 1.15
+filament_spool_weight = 236
+filament_colour = #dfc287
+first_layer_temperature = 200
+temperature = 200
+
+[filament:ColorFabb corkFill]
+inherits = *PLA*
+filament_vendor = ColorFabb
+extrusion_multiplier = 1.1
+filament_cost = 78.63
+filament_density = 1.18
+filament_spool_weight = 236
+filament_colour = #634d33
+first_layer_temperature = 220
+temperature = 220
+
+[filament:ColorFabb XT]
+inherits = *PET*
+filament_vendor = ColorFabb
+filament_cost = 62.90
+filament_density = 1.27
+filament_spool_weight = 236
+first_layer_bed_temperature = 90
+first_layer_temperature = 260
+temperature = 270
+
+[filament:ColorFabb XT-CF20]
+inherits = *PET*
+filament_vendor = ColorFabb
+extrusion_multiplier = 1.05
+filament_cost = 80.65
+filament_density = 1.35
+filament_spool_weight = 236
+filament_colour = #804040
+first_layer_bed_temperature = 90
+first_layer_temperature = 260
+temperature = 260
+
+[filament:ColorFabb nGen]
+inherits = *PET*
+filament_vendor = ColorFabb
+filament_cost = 52.46
+filament_density = 1.2
+filament_spool_weight = 236
+bridge_fan_speed = 40
+fan_always_on = 0
+fan_below_layer_time = 10
+filament_type = NGEN
+first_layer_temperature = 240
+max_fan_speed = 35
+min_fan_speed = 20
+
+[filament:ColorFabb nGen flex]
+inherits = *FLEX*
+filament_vendor = ColorFabb
+filament_cost = 58.30
+filament_density = 1
+filament_spool_weight = 236
+bed_temperature = 85
+bridge_fan_speed = 40
+cooling = 1
+disable_fan_first_layers = 3
+extrusion_multiplier = 1
+fan_below_layer_time = 10
+first_layer_bed_temperature = 85
+first_layer_temperature = 260
+max_fan_speed = 35
+min_fan_speed = 20
+temperature = 260
+
+[filament:Kimya PETG Carbon]
+inherits = *PET*
+filament_vendor = Kimya
+extrusion_multiplier = 1.05
+filament_cost = 150.02
+filament_density = 1.317
+filament_colour = #804040
+first_layer_bed_temperature = 85
+first_layer_temperature = 240
+temperature = 240
+
+[filament:Kimya ABS Carbon]
+inherits = *ABSC*
+filament_vendor = Kimya
+filament_cost = 140.34
+filament_density = 1.032
+filament_colour = #804040
+first_layer_temperature = 260
+temperature = 260
+
+[filament:Kimya ABS Kevlar]
+inherits = Kimya ABS Carbon
+filament_vendor = Kimya
+filament_density = 1.037
+
+[filament:E3D Edge]
+inherits = *PET*
+filament_vendor = E3D
+filament_cost = 56.9
+filament_density = 1.26
+filament_type = EDGE
+
+[filament:E3D PC-ABS]
+inherits = *ABS*
+filament_vendor = E3D
+filament_cost = 0
+filament_type = PC
+filament_density = 1.05
+first_layer_temperature = 270
+temperature = 270
+
+[filament:Fillamentum PLA]
+inherits = *PLA*
+filament_vendor = Fillamentum
+filament_cost = 35.48
+filament_density = 1.24
+filament_spool_weight = 230
+
+[filament:Fillamentum ABS]
+inherits = *ABSC*
+filament_vendor = Fillamentum
+filament_cost = 32.4
+filament_density = 1.04
+filament_spool_weight = 230
+first_layer_temperature = 240
+temperature = 240
+
+[filament:Fillamentum ASA]
+inherits = *ABS*
+filament_vendor = Fillamentum
+filament_cost = 38.7
+filament_density = 1.07
+filament_spool_weight = 230
+fan_always_on = 1
+cooling = 1
+min_fan_speed = 20
+max_fan_speed = 20
+min_print_speed = 15
+slowdown_below_layer_time = 15
+first_layer_temperature = 260
+temperature = 260
+filament_type = ASA
+
+[filament:Prusament ASA]
+inherits = *ABS*
+filament_vendor = Prusa Polymers
+filament_cost = 42.69
+filament_density = 1.07
+filament_spool_weight = 201
+fan_always_on = 1
+first_layer_temperature = 260
+first_layer_bed_temperature = 100
+temperature = 260
+bed_temperature = 100
+cooling = 1
+min_fan_speed = 20
+max_fan_speed = 20
+bridge_fan_speed = 30
+min_print_speed = 15
+slowdown_below_layer_time = 15
+disable_fan_first_layers = 4
+filament_type = ASA
+filament_colour = #FFF2EC
+
+[filament:Prusament PC Blend]
+inherits = *ABS*
+filament_vendor = Prusa Polymers
+filament_cost = 62.36
+filament_density = 1.22
+filament_spool_weight = 201
+fan_always_on = 0
+first_layer_temperature = 275
+first_layer_bed_temperature = 105
+temperature = 275
+bed_temperature = 105
+cooling = 1
+min_fan_speed = 20
+max_fan_speed = 20
+bridge_fan_speed = 30
+min_print_speed = 15
+slowdown_below_layer_time = 20
+disable_fan_first_layers = 4
+fan_below_layer_time = 30
+filament_type = PC
+filament_colour = #DEE0E6
+
+[filament:Prusament PC Blend Carbon Fiber]
+inherits = Prusament PC Blend
+filament_cost = 90.73 
+filament_density = 1.16
+extrusion_multiplier = 1.04
+first_layer_temperature = 285
+temperature = 285
+disable_fan_first_layers = 4
+fan_below_layer_time = 10
+filament_colour = #BBBBBB
+
+[filament:Prusament PA11 Carbon Fiber]
+inherits = Prusament PC Blend Carbon Fiber
+filament_cost = 151.24 
+filament_density = 1.11
+filament_type = PA
+extrusion_multiplier = 1.05
+first_layer_temperature = 275
+temperature = 285
+first_layer_bed_temperature = 90
+bed_temperature = 105
+fan_below_layer_time = 10
+
+[filament:Prusament rPLA]
+inherits = *PLA*
+filament_vendor = Prusa Polymers
+filament_density = 1.24
+filament_spool_weight = 193
+filament_colour = #AA845D
+first_layer_temperature = 205
+temperature = 205
+filament_cost = 37.49
+
+[filament:Prusament Woodfill]
+inherits = *PLA*
+filament_vendor = Prusa Polymers
+extrusion_multiplier = 1
+filament_cost = 42.9
+filament_density = 1.2
+filament_spool_weight = 193
+filament_colour = #dfc287
+first_layer_temperature = 195
+temperature = 195
+
+[filament:Fillamentum CPE]
+inherits = *PET*
+filament_vendor = Fillamentum
+filament_cost = 56.45
+filament_density = 1.25
+filament_spool_weight = 230
+filament_type = CPE
+first_layer_bed_temperature = 90
+first_layer_temperature = 275
+min_fan_speed = 30
+max_fan_speed = 50
+disable_fan_first_layers = 3
+full_fan_speed_layer = 5
+temperature = 275
+
+[filament:Fillamentum Timberfill]
+inherits = *PLA*
+filament_vendor = Fillamentum
+extrusion_multiplier = 1.05
+filament_cost = 68
+filament_density = 1.15
+filament_spool_weight = 230
+filament_colour = #804040
+first_layer_temperature = 190
+temperature = 190
+filament_retract_lift = 0.2
+
+[filament:Smartfil Wood]
+inherits = *PLA*
+filament_vendor = Smart Materials 3D
+extrusion_multiplier = 1.05
+filament_cost = 68
+filament_density = 1.58
+filament_colour = #804040
+first_layer_temperature = 220
+temperature = 220
+
+[filament:Generic ABS]
+inherits = *ABSC*
+filament_vendor = Generic
+filament_cost = 27.82
+filament_density = 1.04
+
+[filament:Esun ABS]
+inherits = *ABSC*
+filament_vendor = Esun
+filament_cost = 27.82
+filament_density = 1.01
+filament_spool_weight = 265
+
+[filament:Hatchbox ABS]
+inherits = *ABSC*
+filament_vendor = Hatchbox
+filament_cost = 27.82
+filament_density = 1.04
+filament_spool_weight = 245
+
+[filament:Filament PM ABS]
+inherits = *ABSC*
+filament_vendor = Filament PM
+filament_cost = 27.82
+filament_density = 1.08
+filament_spool_weight = 230
+
+[filament:Verbatim ABS]
+inherits = *ABSC*
+filament_vendor = Verbatim
+filament_cost = 25.87
+filament_density = 1.05
+filament_spool_weight = 235
+
+[filament:Generic PETG]
+inherits = *PET*
+filament_vendor = Generic
+filament_cost = 27.82
+filament_density = 1.27
+
+[filament:Extrudr DuraPro ASA]
+inherits = Fillamentum ASA
+filament_vendor = Extrudr
+bed_temperature = 90
+filament_cost = 34.64
+filament_density = 1.05
+filament_notes = "https://www.extrudr.com/en/products/catalogue/?material=120"
+first_layer_bed_temperature = 90
+first_layer_temperature = 220
+temperature = 220
+filament_spool_weight = 230
+
+[filament:Extrudr PETG]
+inherits = *PET*
+filament_vendor = Extrudr
+bed_temperature = 70
+filament_cost = 35.45
+filament_density = 1.29
+filament_notes = "https://www.extrudr.com/en/products/catalogue/?material=94"
+first_layer_bed_temperature = 70
+first_layer_temperature = 220
+temperature = 220
+slowdown_below_layer_time = 20
+filament_spool_weight = 262
+full_fan_speed_layer = 0
+
+[filament:Extrudr XPETG CF]
+inherits = Extrudr PETG
+filament_cost = 62.49
+filament_density = 1.29
+filament_notes = "https://www.extrudr.com/en/products/catalogue/?material=198"
+first_layer_temperature = 235
+temperature = 235
+filament_spool_weight = 230
+
+[filament:Extrudr XPETG Matt]
+inherits = Extrudr PETG
+filament_cost = 29.99
+filament_density = 1.41
+filament_notes = "https://www.extrudr.com/en/products/catalogue/?material=199"
+first_layer_temperature = 230
+temperature = 230
+
+[filament:Extrudr BioFusion]
+inherits = *PLA*
+filament_vendor = Extrudr
+disable_fan_first_layers = 3
+full_fan_speed_layer = 0
+filament_cost = 31.23
+filament_density = 1.25
+filament_notes = "https://www.extrudr.com/en/products/catalogue/?material=121"
+first_layer_temperature = 220
+temperature = 220
+max_fan_speed = 45
+min_fan_speed = 25
+slowdown_below_layer_time = 20
+filament_spool_weight = 230
+
+[filament:Extrudr Flax]
+inherits = *PLA*
+filament_vendor = Extrudr
+filament_cost = 50.91
+filament_density = 1.45
+filament_notes = "High Performance Filament for decorative parts.\nPrints as easily as PLA with much higher strength and temperature resistance.\nFully biodegradable with a nice matt finish.\n\nhttps://www.extrudr.com/en/products/catalogue/?material=131"
+first_layer_temperature = 190
+temperature = 190
+max_fan_speed = 80
+min_fan_speed = 30
+full_fan_speed_layer = 0
+slowdown_below_layer_time = 20
+filament_spool_weight = 262
+
+[filament:Extrudr GreenTEC]
+inherits = *PLA*
+filament_vendor = Extrudr
+filament_cost = 50.91
+filament_density = 1.3
+filament_notes = "https://www.extrudr.com/en/products/catalogue/?ignorechildren=1&material=106"
+first_layer_temperature = 208
+temperature = 208
+slowdown_below_layer_time = 20
+filament_spool_weight = 262
+
+[filament:Extrudr GreenTEC Pro]
+inherits = *PLA*
+filament_vendor = Extrudr
+filament_cost = 56.23
+filament_density = 1.35
+filament_notes = "High Performance Filament for technical parts.\nPrints as easily as PLA with much higher strength and temperature resistance.\nFully biodegradable with a nice matt finish.\n\nhttps://www.extrudr.com/en/products/catalogue/?material=134"
+temperature = 215
+max_fan_speed = 80
+min_fan_speed = 30
+full_fan_speed_layer = 0
+slowdown_below_layer_time = 20
+filament_spool_weight = 230
+
+[filament:Extrudr GreenTEC Pro Carbon]
+inherits = *PLA*
+filament_vendor = Extrudr
+filament_cost = 62.49
+filament_density = 1.2
+filament_notes = "High Performance Filament for technical parts.\nPrints as easily as PLA with much higher stregnth and temperature resistance.\nFully biodegradable with a nice matt finish.\n\nhttps://www.extrudr.com/en/products/catalogue/?material=138"
+first_layer_temperature = 225
+max_fan_speed = 80
+min_fan_speed = 30
+temperature = 225
+full_fan_speed_layer = 0
+slowdown_below_layer_time = 20
+filament_spool_weight = 230
+
+[filament:Extrudr PLA NX1]
+inherits = *PLA*
+filament_vendor = Extrudr
+filament_cost = 22.76
+filament_density = 1.24
+filament_notes = "https://www.extrudr.com/en/products/catalogue/?material=97"
+temperature = 205
+bed_temperature = 60
+first_layer_temperature = 205
+first_layer_bed_temperature = 60
+full_fan_speed_layer = 0
+max_fan_speed = 90
+min_fan_speed = 30
+slowdown_below_layer_time = 20
+filament_spool_weight = 262
+
+[filament:Extrudr PLA NX2]
+inherits = Extrudr PLA NX1
+filament_cost = 23.63
+filament_density = 1.3
+filament_notes = "https://www.extrudr.com/en/products/catalogue/?material=128"
+
+[filament:Extrudr Flex Hard]
+inherits = *FLEX*
+filament_vendor = Extrudr
+disable_fan_first_layers = 1
+extrusion_multiplier = 1.15
+filament_cost = 39.98
+filament_density = 1.2
+filament_max_volumetric_speed = 3
+filament_notes = "https://www.extrudr.com/en/products/catalogue/?material=115"
+filament_spool_weight = 230
+slowdown_below_layer_time = 20
+
+[filament:Extrudr Flex Medium]
+inherits = *FLEX*
+filament_vendor = Extrudr
+disable_fan_first_layers = 1
+extrusion_multiplier = 1.15
+filament_cost = 39.98
+filament_density = 1.19
+filament_max_volumetric_speed = 3
+filament_notes = "https://www.extrudr.com/en/products/catalogue/?material=117"
+filament_spool_weight = 230
+slowdown_below_layer_time = 20
+
+[filament:Extrudr Flex SemiSoft]
+inherits = *FLEX*
+filament_vendor = Extrudr
+disable_fan_first_layers = 1
+extrusion_multiplier = 1.15
+filament_cost = 39.98
+filament_density = 1.18
+filament_max_volumetric_speed = 1.8
+filament_notes = "https://www.extrudr.com/en/products/catalogue/?material=116"
+filament_spool_weight = 230
+slowdown_below_layer_time = 20
+
+[filament:addnorth Adamant S1]
+inherits = *FLEX*
+filament_vendor = addnorth
+disable_fan_first_layers = 3
+extrusion_multiplier = 1
+filament_cost = 
+filament_density = 1.22
+temperature = 250
+bed_temperature = 50
+first_layer_temperature = 245
+first_layer_bed_temperature = 50
+slowdown_below_layer_time = 20
+min_print_speed = 20
+fan_below_layer_time = 15
+fan_always_on = 1
+cooling = 1
+min_fan_speed = 40
+max_fan_speed = 70
+bridge_fan_speed = 60
+filament_max_volumetric_speed = 1.7
+
+[filament:addnorth Adura X]
+inherits = *PET*
+filament_vendor = addnorth
+filament_cost = 29.99
+filament_density = 1.27
+filament_type = PA
+extrusion_multiplier = 0.98
+bed_temperature = 105
+first_layer_bed_temperature = 105
+first_layer_temperature = 265
+temperature = 270
+fan_always_on = 0
+min_fan_speed = 20
+max_fan_speed = 40
+bridge_fan_speed = 70
+slowdown_below_layer_time = 10
+min_print_speed = 20
+fan_below_layer_time = 10
+disable_fan_first_layers = 3
+full_fan_speed_layer = 0
+
+[filament:addnorth E-PLA]
+inherits = *PLA*
+filament_vendor = addnorth
+filament_cost = 24.99
+filament_density = 1.24
+extrusion_multiplier = 0.98
+temperature = 215
+bed_temperature = 60
+first_layer_temperature = 215
+first_layer_bed_temperature = 60
+full_fan_speed_layer = 3
+slowdown_below_layer_time = 15
+filament_spool_weight = 0
+
+[filament:addnorth ESD-PETG]
+inherits = *PET*
+filament_vendor = addnorth
+filament_cost = 29.99
+filament_density = 1.27
+extrusion_multiplier = 1
+bed_temperature = 80
+first_layer_bed_temperature = 85
+first_layer_temperature = 245
+temperature = 265
+fan_always_on = 1
+min_fan_speed = 15
+max_fan_speed = 30
+bridge_fan_speed = 35
+slowdown_below_layer_time = 10
+min_print_speed = 15
+fan_below_layer_time = 8
+disable_fan_first_layers = 3
+full_fan_speed_layer = 0
+
+[filament:addnorth OBC Polyethylene]
+inherits = *FLEX*
+filament_vendor = addnorth
+disable_fan_first_layers = 3
+extrusion_multiplier = 1
+filament_cost = 82
+filament_density = 1.22
+temperature = 200
+bed_temperature = 100
+first_layer_temperature = 195
+first_layer_bed_temperature = 100
+slowdown_below_layer_time = 5
+fan_below_layer_time = 15
+fan_always_on = 1
+cooling = 1
+min_fan_speed = 20
+max_fan_speed = 30
+bridge_fan_speed = 40
+min_print_speed = 20
+filament_spool_weight = 0
+filament_notes = "Use Magigoo PP bed adhesive or PP packing tape (on a cold printbed)."
+
+[filament:addnorth PETG]
+inherits = *PET*
+filament_vendor = addnorth
+filament_cost = 29.99
+filament_density = 1.27
+bed_temperature = 80
+first_layer_bed_temperature = 85
+first_layer_temperature = 240
+temperature = 250
+fan_always_on = 1
+min_fan_speed = 15
+max_fan_speed = 40
+bridge_fan_speed = 50
+slowdown_below_layer_time = 10
+min_print_speed = 15
+fan_below_layer_time = 15
+disable_fan_first_layers = 3
+full_fan_speed_layer = 0
+filament_spool_weight = 0
+
+[filament:addnorth Rigid X]
+inherits = *PET*
+filament_vendor = addnorth
+filament_cost = 29.99
+filament_density = 1.27
+extrusion_multiplier = 1
+bed_temperature = 85
+first_layer_bed_temperature = 90
+first_layer_temperature = 250
+temperature = 260
+fan_always_on = 1
+min_fan_speed = 20
+max_fan_speed = 60
+bridge_fan_speed = 70
+slowdown_below_layer_time = 10
+fan_below_layer_time = 20
+min_print_speed = 20
+disable_fan_first_layers = 3
+full_fan_speed_layer = 0
+filament_spool_weight = 0
+filament_notes = "Please use a nozzle that is resistant to abrasive filaments, like hardened steel."
+
+[filament:addnorth Textura]
+inherits = *PLA*
+filament_vendor = addnorth
+filament_cost = 24.99
+filament_density = 1.24
+extrusion_multiplier = 0.95
+temperature = 215
+bed_temperature = 65
+first_layer_temperature = 215
+first_layer_bed_temperature = 65
+min_fan_speed = 20
+max_fan_speed = 40
+bridge_fan_speed = 60
+full_fan_speed_layer = 0
+slowdown_below_layer_time = 15
+min_print_speed = 20
+filament_spool_weight = 0
+
+[filament:Filamentworld ABS]
+inherits = *ABSC*
+filament_vendor = Filamentworld
+filament_cost = 24.9
+filament_density = 1.04
+temperature = 230
+bed_temperature = 95
+first_layer_temperature = 240
+first_layer_bed_temperature = 100
+max_fan_speed = 20
+min_fan_speed = 10
+min_print_speed = 20
+disable_fan_first_layers = 3
+fan_below_layer_time = 60
+slowdown_below_layer_time = 15
+bridge_fan_speed = 20
+
+[filament:Filamentworld PETG]
+inherits = *PET*
+filament_vendor = Filamentworld
+filament_cost = 34.9
+filament_density = 1.27
+bed_temperature = 70
+first_layer_bed_temperature = 85
+first_layer_temperature = 240
+temperature = 235
+fan_always_on = 1
+min_fan_speed = 25
+max_fan_speed = 55
+bridge_fan_speed = 55
+slowdown_below_layer_time = 20
+min_print_speed = 20
+fan_below_layer_time = 35
+disable_fan_first_layers = 2
+full_fan_speed_layer = 0
+filament_spool_weight = 0
+
+[filament:Filamentworld PLA]
+inherits = *PLA*
+filament_vendor = Filamentworld
+filament_cost = 24.9
+filament_density = 1.24
+temperature = 205
+bed_temperature = 55
+first_layer_temperature = 215
+first_layer_bed_temperature = 60
+full_fan_speed_layer = 3
+slowdown_below_layer_time = 10
+filament_spool_weight = 0
+min_print_speed = 20
+
+[filament:Filament PM PETG]
+inherits = *PET*
+filament_vendor = Filament PM
+filament_cost = 27.82
+filament_density = 1.27
+filament_spool_weight = 230
+
+[filament:Generic PLA]
+inherits = *PLA*
+filament_vendor = Generic
+filament_cost = 25.4
+filament_density = 1.24
+
+# Discontinued
+
+# [filament:3D-Fuel Standard PLA]
+# inherits = *PLA*
+# filament_vendor = 3D-Fuel
+# filament_cost = 22.14
+# filament_density = 1.24
+# first_layer_temperature = 210
+# temperature = 200
+
+# [filament:3D-Fuel EasiPrint PLA]
+# inherits = 3D-Fuel Standard PLA
+# filament_cost = 30.44
+
+# [filament:3D-Fuel Pro PLA]
+# inherits = *PLA*
+# filament_vendor = 3D-Fuel
+# filament_cost = 26.57
+# filament_density = 1.22
+# first_layer_temperature = 220
+# temperature = 215
+
+# [filament:3D-Fuel Buzzed]
+# inherits = 3D-Fuel Standard PLA
+# filament_cost = 44.27
+# filament_retract_lift = 0
+# first_layer_temperature = 210
+# temperature = 195
+
+# [filament:3D-Fuel Wound up]
+# inherits = 3D-Fuel Buzzed
+# filament_cost = 44.27
+# filament_retract_lift = nil
+# first_layer_temperature = 215
+# temperature = 210
+
+# [filament:3D-Fuel Workday ABS]
+# inherits = *ABSC*
+# filament_vendor = 3D-Fuel
+# filament_cost = 23.25
+# filament_density = 1.04
+
+[filament:3D-Fuel Pro PCTG]
+inherits = *PET*
+bed_temperature = 80    
+cooling = 1
+disable_fan_first_layers = 3
+fan_below_layer_time = 20
+filament_max_volumetric_speed = 8
+filament_type = PCTG
+filament_density = 1.23
+filament_cost = 29.95
+filament_vendor = 3D-Fuel
+first_layer_bed_temperature = 80
+first_layer_temperature = 255
+fan_always_on = 1
+max_fan_speed = 40
+min_fan_speed = 0
+bridge_fan_speed = 80
+temperature = 255
+
+[filament:3D-Fuel PET-CF]
+inherits = *PET*
+bed_temperature = 80    
+cooling = 1
+disable_fan_first_layers = 3
+fan_below_layer_time = 20
+filament_max_volumetric_speed = 8
+filament_type = PET
+filament_density = 1.4
+filament_cost = 99.90
+filament_vendor = 3D-Fuel
+first_layer_bed_temperature = 80
+first_layer_temperature = 260
+fan_always_on = 1
+max_fan_speed = 20
+min_fan_speed = 0
+bridge_fan_speed = 20
+temperature = 260
+
+[filament:3D-Fuel Standard PLA+]
+inherits = *PLA*
+bed_temperature = 60    
+cooling = 1
+disable_fan_first_layers = 3
+fan_below_layer_time = 20
+filament_max_volumetric_speed = 10
+filament_type = PLA
+filament_density = 1.24
+filament_cost = 29.90
+filament_vendor = 3D-Fuel
+first_layer_bed_temperature = 60
+first_layer_temperature = 215
+fan_always_on = 1
+max_fan_speed = 100
+min_fan_speed = 100
+bridge_fan_speed = 100
+temperature = 215
+
+[filament:3D-Fuel Tough Pro PLA+]
+inherits = *PLA*
+bed_temperature = 60    
+cooling = 1
+disable_fan_first_layers = 3
+fan_below_layer_time = 20
+filament_max_volumetric_speed = 10
+filament_type = PLA
+filament_density = 1.24
+filament_cost = 32.95
+filament_vendor = 3D-Fuel
+first_layer_bed_temperature = 60
+first_layer_temperature = 220
+fan_always_on = 1
+max_fan_speed = 100
+min_fan_speed = 100
+bridge_fan_speed = 100
+temperature = 220
+
+[filament:3D-Fuel Silk PLA+]
+inherits = *PLA*
+bed_temperature = 60    
+cooling = 1
+disable_fan_first_layers = 3
+fan_below_layer_time = 20
+filament_max_volumetric_speed = 10
+filament_type = PLA
+filament_density = 1.24
+filament_cost = 29.90
+filament_vendor = 3D-Fuel
+first_layer_bed_temperature = 60
+first_layer_temperature = 210
+fan_always_on = 1
+max_fan_speed = 100
+min_fan_speed = 100
+bridge_fan_speed = 100
+temperature = 210
+
+[filament:3D-Fuel Tough Pro PLA+ ReFuel]
+inherits = *PLA*
+bed_temperature = 60    
+cooling = 1
+disable_fan_first_layers = 3
+fan_below_layer_time = 20
+filament_max_volumetric_speed = 10
+filament_type = PLA
+filament_density = 1.24
+filament_cost = 32.95
+filament_vendor = 3D-Fuel
+first_layer_bed_temperature = 60
+first_layer_temperature = 220
+fan_always_on = 1
+max_fan_speed = 100
+min_fan_speed = 100
+bridge_fan_speed = 100
+temperature = 220
+
+[filament:3D-Fuel Standard PLA+ ReFuel]
+inherits = *PLA*
+bed_temperature = 60    
+cooling = 1
+disable_fan_first_layers = 3
+fan_below_layer_time = 20
+filament_max_volumetric_speed = 10
+filament_type = PLA
+filament_density = 1.24
+filament_cost = 25.95
+filament_vendor = 3D-Fuel
+first_layer_bed_temperature = 60
+first_layer_temperature = 210
+fan_always_on = 1
+max_fan_speed = 100
+min_fan_speed = 100
+bridge_fan_speed = 100
+temperature = 210
+
+[filament:3D-Fuel Pro PCTG ReFuel]
+inherits = *PET*
+bed_temperature = 80    
+cooling = 1
+disable_fan_first_layers = 3
+fan_below_layer_time = 20
+filament_max_volumetric_speed = 8
+filament_type = PCTG
+filament_density = 1.23
+filament_cost = 39.90
+filament_vendor = 3D-Fuel
+first_layer_bed_temperature = 80
+first_layer_temperature = 255
+fan_always_on = 1
+max_fan_speed = 40
+min_fan_speed = 0
+bridge_fan_speed = 80
+temperature = 255
+
+[filament:3D-Fuel Pro PETG]
+inherits = *PET*
+bed_temperature = 80
+cooling = 1
+disable_fan_first_layers = 3
+fan_below_layer_time = 20
+filament_max_volumetric_speed = 8
+filament_type = PETG
+filament_density = 1.23
+filament_cost = 29.95
+filament_vendor = 3D-Fuel
+first_layer_bed_temperature = 80
+first_layer_temperature = 255
+fan_always_on = 1
+max_fan_speed = 40
+min_fan_speed = 0
+bridge_fan_speed = 80
+temperature = 255
+
+[filament:3D-Fuel Pro PETG Refuel]
+inherits = *PET*
+bed_temperature = 80
+cooling = 1
+disable_fan_first_layers = 3
+fan_below_layer_time = 20
+filament_max_volumetric_speed = 8
+filament_type = PETG
+filament_density = 1.23
+filament_cost = 28.95
+filament_vendor = 3D-Fuel
+first_layer_bed_temperature = 80
+first_layer_temperature = 255
+fan_always_on = 1
+max_fan_speed = 40
+min_fan_speed = 0
+bridge_fan_speed = 80
+temperature = 255
+
+[filament:Tectonic-3D AURA PLA]
+inherits = *PLA*
+first_layer_bed_temperature = 60
+bed_temperature = 60
+first_layer_temperature = 220
+temperature = 215
+filament_vendor = Tectonic-3D
+filament_cost = 22
+filament_density = 1.24
+filament_spool_weight = 200
+
+[filament:Tectonic-3D AURA PETG]
+inherits = *PET*
+filament_vendor = Tectonic-3D
+filament_cost = 25
+filament_spool_weight = 155
+filament_density = 1.29
+first_layer_temperature = 245
+first_layer_bed_temperature = 85
+temperature = 245
+bed_temperature = 85
+
+[filament:Tectonic-3D AURA ASA+]
+inherits = *ABS*
+filament_vendor = Tectonic-3D
+filament_cost = 38.7
+filament_density = 1.07
+fan_always_on = 1
+cooling = 1
+min_fan_speed = 20
+max_fan_speed = 20
+min_print_speed = 20
+slowdown_below_layer_time = 15
+first_layer_temperature = 260
+temperature = 260
+filament_type = ASA
+first_layer_bed_temperature = 90
+bed_temperature = 90
+disable_fan_first_layers = 4
+
+[filament:Cookiecad PLA]
+inherits = *PLA*
+filament_vendor = Cookiecad
+filament_cost = 34.95
+filament_density = 1.25
+filament_spool_weight = 180
+first_layer_bed_temperature = 70
+
+[filament:Polymaker PolyTerra PLA]
+inherits = *PLA*
+filament_vendor = Polymaker
+filament_cost = 25
+filament_density = 1.31
+filament_spool_weight = 140
+first_layer_temperature = 230
+temperature = 215
+
+[filament:Sunlu PLA+ 2.0]
+inherits = *PLA*
+filament_vendor = Sunlu
+filament_cost = 22
+filament_density = 1.23
+filament_spool_weight = 162
+first_layer_temperature = 230
+temperature = 220
+
+[filament:Sunlu PLA]
+inherits = *PLA*
+first_layer_bed_temperature = 60
+bed_temperature = 60
+first_layer_temperature = 220
+temperature = 215
+filament_vendor = Sunlu
+filament_cost = 15
+filament_density = 1.23
+filament_spool_weight = 162
+
+[filament:Sunlu PETG]
+inherits = *PET*
+filament_vendor = Sunlu
+filament_cost = 15
+filament_spool_weight = 162
+filament_density = 1.23
+first_layer_temperature = 240
+first_layer_bed_temperature = 85
+temperature = 240
+bed_temperature = 90
+
+[filament:Jessie PLA]
+inherits = *PLA*
+filament_vendor = Printed Solid
+filament_cost = 21
+filament_density = 1.24
+
+[filament:Jessie PETG]
+inherits = *PET*
+filament_vendor = Printed Solid
+filament_cost = 22
+filament_density = 1.27
+first_layer_temperature = 240
+first_layer_bed_temperature = 85
+temperature = 245
+bed_temperature = 90
+
+[filament:VOXELPLA+]
+inherits = *PLA*
+filament_vendor = VOXELPLA
+filament_cost = 21
+filament_density = 1.23
+first_layer_temperature = 220
+temperature = 215
+
+[filament:VOXELPETG+]
+inherits = *PET*
+filament_vendor = VOXELPLA
+filament_cost = 22
+filament_density = 1.27
+first_layer_temperature = 240
+first_layer_bed_temperature = 80
+temperature = 240
+bed_temperature = 80
+
+[filament:Devil Design PLA]
+inherits = *PLA*
+filament_vendor = Devil Design
+filament_cost = 20.99
+filament_density = 1.24
+filament_spool_weight = 250
+
+[filament:Devil Design PETG]
+inherits = *PET*
+filament_vendor = Devil Design
+filament_cost = 20.99
+filament_density = 1.23
+filament_spool_weight = 250
+first_layer_temperature = 230
+first_layer_bed_temperature = 85
+temperature = 230
+bed_temperature = 90
+
+[filament:Spectrum PLA]
+inherits = *PLA*
+filament_vendor = Spectrum
+filament_cost = 21.50
+filament_density = 1.24
+
+[filament:Generic FLEX]
+inherits = *FLEX*
+filament_vendor = Generic
+filament_cost = 82
+filament_density = 1.22
+filament_max_volumetric_speed = 1.2
+filament_retract_length = 0
+filament_retract_speed = nil
+filament_retract_lift = nil
+
+[filament:Fillamentum Flexfill 92A]
+inherits = *FLEX*
+filament_vendor = Fillamentum
+filament_cost = 33.99
+filament_density = 1.20
+filament_spool_weight = 230
+filament_max_volumetric_speed = 1.2
+fan_always_on = 1
+cooling = 0
+max_fan_speed = 60
+min_fan_speed = 60
+disable_fan_first_layers = 4
+full_fan_speed_layer = 6
+
+[filament:AmazonBasics TPU]
+inherits = *FLEX*
+filament_vendor = AmazonBasics
+fan_always_on = 1
+filament_max_volumetric_speed = 1.8
+extrusion_multiplier = 1.14
+first_layer_temperature = 235
+first_layer_bed_temperature = 50
+temperature = 235
+bed_temperature = 50
+bridge_fan_speed = 100
+max_fan_speed = 80
+min_fan_speed = 80
+filament_retract_before_travel = 3
+filament_cost = 19.99
+filament_density = 1.21
+disable_fan_first_layers = 4
+full_fan_speed_layer = 6
+min_print_speed = 15
+slowdown_below_layer_time = 10
+cooling = 1
+
+[filament:SainSmart TPU]
+inherits = *FLEX*
+filament_vendor = SainSmart
+fan_always_on = 1
+filament_max_volumetric_speed = 2.5
+extrusion_multiplier = 1.05
+first_layer_temperature = 230
+first_layer_bed_temperature = 50
+temperature = 230
+bed_temperature = 50
+bridge_fan_speed = 100
+max_fan_speed = 80
+min_fan_speed = 80
+filament_retract_before_travel = 3
+filament_cost = 32.99
+filament_density = 1.21
+disable_fan_first_layers = 4
+full_fan_speed_layer = 6
+min_print_speed = 15
+slowdown_below_layer_time = 10
+cooling = 1
+
+[filament:NinjaTek NinjaFlex TPU]
+inherits = *FLEX*
+filament_vendor = NinjaTek
+fan_always_on = 1
+filament_max_volumetric_speed = 1.2
+extrusion_multiplier = 1.15
+first_layer_temperature = 238
+first_layer_bed_temperature = 50
+temperature = 238
+bed_temperature = 50
+bridge_fan_speed = 75
+max_fan_speed = 60
+min_fan_speed = 60
+filament_cost = 85
+filament_density = 1.19
+disable_fan_first_layers = 1
+full_fan_speed_layer = 3
+min_print_speed = 10
+slowdown_below_layer_time = 10
+cooling = 1
+
+[filament:NinjaTek Cheetah TPU]
+inherits = NinjaTek NinjaFlex TPU
+filament_retract_length = 1.5
+filament_density = 1.22
+filament_max_volumetric_speed = 4
+extrusion_multiplier = 1.05
+filament_retract_speed = 45
+filament_deretract_speed = 25
+first_layer_temperature = 240
+temperature = 240
+
+[filament:Filatech FilaFlex40]
+inherits = *FLEX*
+filament_vendor = Filatech
+fan_always_on = 1
+filament_max_volumetric_speed = 2.5
+extrusion_multiplier = 1.1
+first_layer_temperature = 230
+first_layer_bed_temperature = 50
+temperature = 230
+bed_temperature = 50
+bridge_fan_speed = 100
+max_fan_speed = 50
+min_fan_speed = 50
+filament_cost = 84.68
+filament_density = 1.22
+disable_fan_first_layers = 4
+full_fan_speed_layer = 6
+min_print_speed = 15
+slowdown_below_layer_time = 10
+cooling = 1
+
+[filament:Filatech FilaFlex30]
+inherits = Filatech FilaFlex40
+temperature = 225
+filament_density = 1.15
+extrusion_multiplier = 1.1
+filament_cost =
+
+[filament:Filatech FilaFlex55]
+inherits = Filatech FilaFlex40
+temperature = 230
+filament_density = 1.18
+bed_temperature = 60
+fan_always_on = 0
+fan_below_layer_time = 60
+filament_cost =
+first_layer_temperature = 235
+extrusion_multiplier = 1
+
+[filament:Filatech TPU]
+inherits = Filatech FilaFlex40
+first_layer_temperature = 230
+filament_density = 1.2
+fan_below_layer_time = 60
+max_fan_speed = 80
+min_fan_speed = 80
+fan_always_on = 1
+temperature = 235
+
+[filament:Filatech ABS]
+inherits = *ABSC*
+filament_vendor = Filatech
+filament_cost = 
+extrusion_multiplier = 1
+filament_density = 1.05
+
+[filament:Filatech FilaCarbon]
+inherits = *ABSC*
+filament_vendor = Filatech
+filament_cost = 
+extrusion_multiplier = 0.95
+filament_density = 1.1
+first_layer_bed_temperature = 100
+bed_temperature = 100
+
+[filament:Filatech FilaPLA]
+inherits = *PLA*
+filament_vendor = Filatech
+filament_cost = 
+filament_density = 1.3
+first_layer_temperature = 235
+first_layer_bed_temperature = 50
+temperature = 230
+bed_temperature = 55
+
+[filament:Filatech PLA]
+inherits = *PLA*
+filament_vendor = Filatech
+filament_cost = 
+filament_density = 1.25
+first_layer_temperature = 215
+temperature = 210
+
+[filament:Filatech PLA+]
+inherits = Filatech PLA
+filament_density = 1.24
+
+[filament:Filatech FilaTough]
+inherits = Filatech ABS
+filament_cost = 
+extrusion_multiplier = 0.95
+filament_density = 1.29
+first_layer_temperature = 245
+first_layer_bed_temperature = 80
+temperature = 240
+bed_temperature = 90
+cooling = 0
+
+[filament:Filatech HIPS]
+inherits = Prusa HIPS
+filament_vendor = Filatech
+filament_density = 1.07
+filament_spool_weight = 
+first_layer_temperature = 230
+first_layer_bed_temperature = 100
+temperature = 225
+bed_temperature = 100
+
+[filament:Filatech PA]
+inherits = *ABSC*
+filament_vendor = Filatech
+filament_density = 1.1
+first_layer_temperature = 275
+first_layer_bed_temperature = 105
+temperature = 275
+bed_temperature = 105
+fan_always_on = 0
+cooling = 0
+bridge_fan_speed = 25
+filament_type = PA
+
+[filament:Filatech PC]
+inherits = Filatech PA
+filament_density = 1.2
+filament_type = PC
+
+[filament:Filatech PC-ABS]
+inherits = Filatech PC
+first_layer_temperature = 270
+temperature = 270
+first_layer_bed_temperature = 105
+bed_temperature = 105
+filament_density = 1.08
+filament_type = PC
+fan_always_on = 0
+cooling = 1
+extrusion_multiplier = 0.95
+disable_fan_first_layers = 6
+
+[filament:Filatech PETG]
+inherits = *PET*
+filament_vendor = Filatech
+filament_cost = 
+filament_density = 1.27
+first_layer_temperature = 240
+first_layer_bed_temperature = 75
+temperature = 245
+bed_temperature = 80
+extrusion_multiplier = 0.95
+fan_always_on = 0
+
+[filament:Filatech Wood-PLA]
+inherits = Filatech PLA
+filament_density = 1.05
+first_layer_temperature = 210
+
+[filament:Ultrafuse PET]
+inherits = *PET*
+filament_vendor = BASF
+filament_density = 1.33
+filament_colour = #F7F7F7
+first_layer_temperature = 220
+first_layer_bed_temperature = 70
+temperature = 215
+bed_temperature = 70
+fan_below_layer_time = 10
+min_fan_speed = 75
+max_fan_speed = 100
+bridge_fan_speed = 100
+filament_type = PET
+disable_fan_first_layers = 1
+full_fan_speed_layer = 3
+filament_notes = "Material Description\nUltrafuse PET is made from a premium PET and prints as easy as PLA, but is much stronger. The filament has a large operating window for printing (temperature vs. speed), so it can be used on every 3D-printer. PET will give you outstanding printing results: a good layer adhesion, a high resolution and it is easy to handle. Ultrafuse PET can be 100% recycled, is watertight and has great colors and finish.\n\nPrinting Recommendations:\nUltrafuse PET can be printed directly onto a clean build plate. For challenging prints, use 3dLac to improve adhesion."
+
+[filament:Ultrafuse PRO1]
+inherits = Prusament PLA
+filament_vendor = BASF
+filament_cost = 
+filament_density = 1.25
+filament_spool_weight = 0
+filament_colour = #FFFFFF
+filament_notes = "Material Description\nPLA PRO1 is an extremely versatile tough PLA filament made for professionals. It reduces your printing time by 30% – 80%, (subject to printer and object limitations) and the strength exceeds overall mechanical properties of printed ABS parts. Printer settings can be tuned to achieve blazing fast speeds or an unrivaled surface finish. The excellent quality control ensures the highest levels of consistency between colors and batches, it will perform as expected, every time.\n\nPrinting Recommendations:\nUltrafuse PLA PRO1 can be printed directly onto a clean build plate."
+
+[filament:Ultrafuse ABS]
+inherits = *ABSC*
+filament_vendor = BASF
+filament_density = 1.04
+min_fan_speed = 10
+max_fan_speed = 20
+bed_temperature = 100
+disable_fan_first_layers = 3
+filament_colour = #FFFFFF
+filament_notes = "Material Description\nABS is the second most used 3D printing material. It is strong, flexible and has a high heat resistance. ABS is a preferred plastic for engineers and professional applications. ABS can be smoothened with acetone. To make a proper 3D print with ABS you will need a heated print bed. The filament is available in 9 colors.\n\nPrinting Recommendations:\n\nApply Tape, adhesion spray or glue to a clean build plate to improve adhesion."
+
+[filament:Ultrafuse ABS Fusion+]
+inherits = Ultrafuse ABS
+filament_density = 1.08
+first_layer_bed_temperature = 100
+first_layer_temperature = 270
+temperature = 270
+filament_colour = #FFF8D9
+filament_notes = "Material Description\nABS Fusion+ made with Polyscope XILOY™ 3D is an engineering filament which has been optimized for 3D-printing. This special grade has been developed in collaboration with Polyscope Polymers - renowned for its material solutions in the automotive industry. ABS is a thermoplastic which is used in many applications. Although ABS has been classified as a standard material in 3D-printing it is known to be quite challenging to process. ABS Fusion+ combines the properties of ABS with an improved processability. The filament is based on an ABS grade which can be directly printed on glass without any adhesives or tape and has a higher success rate of prints due to extreme low warping."
+
+[filament:Ultrafuse ASA]
+inherits = Ultrafuse ABS Fusion+
+filament_density = 1.07
+filament_colour = #FFF4CA
+first_layer_temperature = 275
+temperature = 275
+first_layer_bed_temperature = 100
+bed_temperature = 100
+filament_type = ASA
+min_fan_speed = 25
+max_fan_speed = 50
+bridge_fan_speed = 100
+disable_fan_first_layers = 4
+filament_notes = "Material Description\nUltrafuse ASA is a high-performance thermoplastic with similar mechanical properties as ABS. ASA offers additional benefits such as high outdoor weather resistance. The UV resistance, toughness, and rigidity make it an ideal material to 3D-print outdoor fixtures and appliances without losing its properties or color. When also taking into account the high heat resistance and high chemical resistance, this filament is a good choice for many types of applications.\n\nPrinting Recommendations:\nApply Magigoo PC, 3D lac or Dimafix to a clean build plate to improve adhesion."
+
+[filament:Ultrafuse HIPS]
+inherits = Ultrafuse ABS
+temperature = 250
+filament_density = 1.02
+filament_type = HIPS
+min_fan_speed = 20
+max_fan_speed = 20
+filament_soluble = 1
+filament_notes = "Material Description\nUltrafuse HIPS is a high-quality engineering thermoplastic, which is well known in the 3D-printing industry as a support material for ABS. But this material has additional properties to offer like good impact resistance, good dimensional stability, and easy post-processing. HiPS is a great material to use as a support for ABS because there is a good compatibility between the two materials, and HIPS is an easy breakaway support. Now you have the opportunity to create ABS models with complex geometry. HIPS is easy to post process with glue or with sanding paper."
+
+[filament:Ultrafuse PA]
+inherits = Fillamentum Nylon FX256
+filament_vendor = BASF
+filament_density = 1.12
+filament_colour = #ECFAFF
+first_layer_temperature = 240
+temperature = 240
+first_layer_bed_temperature = 80
+bed_temperature = 70
+min_fan_speed = 0
+max_fan_speed = 0
+bridge_fan_speed = 0
+fan_below_layer_time = 30
+slowdown_below_layer_time = 20
+min_print_speed = 15
+filament_notes = "Material Description\nThe key features of Ultrafuse PA are the high strength and high modulus. Furthermore, Ultrafuse PA shows a good thermal distortion stability.\n\nPrinting Recommendations:\nApply PVA glue, Kapton tape or PA adhesive to a clean buildplate to improve adhesion."
+
+[filament:Ultrafuse PA6 GF30]
+inherits = Ultrafuse PA
+filament_density = 1.17
+first_layer_temperature = 270
+temperature = 270
+first_layer_bed_temperature = 100
+bed_temperature = 100
+filament_colour = #404040
+fan_always_on = 1
+min_fan_speed = 0
+max_fan_speed = 50
+bridge_fan_speed = 100
+disable_fan_first_layers = 1
+full_fan_speed_layer = 3
+slowdown_below_layer_time = 15
+filament_notes = "Material Description\nUltrafuse® PA6 GF30 is a unique compound specifically developed for FFF printing. Due to the glass fiber content of 30%, parts tend to warp less. In addition the excellent layer adhesion and its compatibility with the water soluble support Ultrafuse® BVOH make this material the perfect solution to develop industrial applications on an FFF printer.\n\nWith its high wear and chemical resistance, high stiffness and strength, Ultrafuse® PA6 GF30 is perfect for a wide variety of applications in automotive, electronics or transportation.\n\nUltrafuse PA6 GF30 is designed for functional prototyping and demanding applications such as industrial tooling, transportation, electronics, small appliances, sports & leisure\n\nPrinting Recommendations:\nThis material contains fibers that have an abrasive effect on printer components. Use a hardened or Ruby nozzle with a diameter of 0.6 or larger for optimal performance and avoid damage to the nozzle.\n\nUltrafuse PA6 GF30 can be printed directly onto a clean build plate. For challenging prints, use Magigoo PA gluestick  to improve adhesion."
+
+[filament:Ultrafuse PAHT-CF15]
+inherits = Ultrafuse PA6 GF30
+filament_density = 1.23
+filament_notes = "Material Description\nPAHT CF15 is a high-performance 3D printing filament that opens new application fields in FFF printing. In parallel to its advanced mechanical properties, dimensional stability, and chemical resistance, it has very good processability. It works in any FFF printer with a hardened nozzle. In addition to that, it is compatible with water-soluble support material and HiPS, which allow printing complex geometries that work in challenging environments. PAHT CF15 has high heat resistance up to 130 °C and low moisture absorption.\n\nPrinting Recommendations:\nThis material contains fibers that have an abrasive effect on printer components. Use a hardened or Ruby nozzle with a diameter of 0.6 or larger for optimal performance and avoid damage to the nozzle.\n\nUltrafuse PAHT-CF can be printed directly onto a clean build plate. For challenging prints, use 3dLac to improve adhesion."
+
+[filament:Ultrafuse PC-ABS-FR]
+inherits = Ultrafuse ABS
+filament_colour = #505050
+filament_density = 1.17
+first_layer_temperature = 275
+temperature = 275
+first_layer_bed_temperature = 105
+bed_temperature = 105
+filament_type = PC
+min_fan_speed = 20
+max_fan_speed = 20
+bridge_fan_speed = 30
+disable_fan_first_layers = 4
+filament_notes = "Material Description\nUltrafuse® PC/ABS FR Black is a V-0 flame retardant blend of Polycarbonate and ABS – two of the most used thermoplastics for engineering & electrical applications. The combination of these two materials results in a premium material with a mix of the excellent mechanical properties of PC and the comparably low printing temperature of ABS. Combined with a halogen free flame retardant, parts printed with Ultrafuse® PC/ABS FR Black feature great tensile and impact strength, higher thermal resistance than ABS and can fulfill the requirements of the UL94 V-0 standard.\n\nPrinting Recommendations:\nApply Magigoo PC to a clean build plate to improve adhesion."
+
+[filament:Ultrafuse PET-CF15]
+inherits = Ultrafuse PET
+filament_density = 1.36
+filament_colour = #404040
+first_layer_temperature = 270
+temperature = 270
+first_layer_bed_temperature = 75
+bed_temperature = 75
+min_fan_speed = 60
+max_fan_speed = 100
+bridge_fan_speed = 100
+disable_fan_first_layers = 1
+full_fan_speed_layer = 3
+slowdown_below_layer_time = 15
+fan_below_layer_time = 30
+filament_notes = "Material Description\nPET CF15 is a Carbon Fiber reinforced PET which has precisely tuned material properties, for a wide range of technical applications. The filament is very strong and stiff and has high heat resistance. With its high dimensional stability and low abrasiveness, the filament offers an easy to print experience which allows direct printing on glass or a PEI sheet. It is compatible with HiPS for breakaway support and water soluble support and has an excellent surface finish.\n\nPrinting Recommendations:\nThis material contains fibers that have an abrasive effect on printer components. Use a hardened or Ruby nozzle with a diameter of 0.6 or larger for optimal performance and avoid damage to the nozzle.\n\nUltrafuse PET-CF15 can be printed directly onto a clean build plate. For challenging prints, use 3dLac to improve adhesion."
+
+[filament:Ultrafuse PLA]
+inherits = *PLA*
+filament_vendor = BASF
+filament_density = 1.25
+full_fan_speed_layer = 3
+filament_notes = "Material Description\nPLA is one of the most used materials for 3D printing. Ultrafuse PLA is available in a wide range of colors. The glossy feel often attracts those who print display models or items for household use. Many appreciate the plant-based origin of this material. When properly cooled, PLA has a high maximum printing speed and sharp printed corners. Combining this with low warping of the print makes it a popular plastic for home printers, hobbyists, prototyping and schools.\n\nPrinting Recommendations:\nUltrafuse PLA can be printed directly onto a clean build plate."
+
+[filament:Ultrafuse PP]
+inherits = Ultrafuse ABS
+filament_density = 0.91
+filament_colour = #F0F0F0
+first_layer_temperature = 240
+temperature = 240
+first_layer_bed_temperature = 80
+bed_temperature = 70
+min_fan_speed = 100
+max_fan_speed = 100
+bridge_fan_speed = 100
+disable_fan_first_layers = 1
+full_fan_speed_layer = 3
+fan_below_layer_time = 60
+slowdown_below_layer_time = 20
+min_print_speed = 10
+filament_type = PP
+filament_max_volumetric_speed = 2.5
+filament_notes = "Material Description\nUltrafuse PP is high-performance thermoplastic with low density, high elasticity and high resistance to fatigue. The mechanical properties make it an ideal material for 3D-printing applications which have to endure high stress or strain. The filament has high chemical resistance and a high isolation value. PP is one of the most used materials in the world, due to its versatility and ability to engineer lightweight tough parts.\n\nPrinting Recommendations:\nApply PP tape or Magigoo PP adhesive to the buildplate for optimal adhesion."
+
+[filament:Ultrafuse PP-GF30]
+inherits = Ultrafuse PP
+filament_density = 1.07
+filament_colour = #404040
+first_layer_temperature = 260
+temperature = 250
+first_layer_bed_temperature = 90
+bed_temperature = 40
+min_fan_speed = 40
+max_fan_speed = 75
+fan_always_on = 1
+fan_below_layer_time = 30
+slowdown_below_layer_time = 15
+min_print_speed = 15
+filament_notes = "Ultrafuse PP GF30 is polypropylene, reinforced with 30% glass fiber content. The fibers in this compound are specially designed for 3D-printing filaments and are compatible with a wide range of standard FFF 3D-printers. The extreme stiffness makes this material highly suitable for demanding applications. Other key properties of PPGF30 are high heat resistance and improved UV-resistance. All these excellent properties make this filament highly suitable in an industrial environment.\n\nPrinting Recommendations:\nThis material contains fibers that have an abrasive effect on printer components. Use a hardened or Ruby nozzle with a diameter of 0.6 or larger for optimal performance and avoid damage to the nozzle.\n\nApply PP strapping tape or PPGF adhesive to a clean build plate for optimal adhesion."
+
+[filament:Ultrafuse TPC-45D]
+inherits = *FLEX*
+filament_vendor = BASF
+extrusion_multiplier = 1
+filament_density = 1.15
+filament_colour = #0035EC
+first_layer_temperature = 235
+temperature = 235
+first_layer_bed_temperature = 60
+bed_temperature = 60
+min_fan_speed = 10
+max_fan_speed = 50
+bridge_fan_speed = 80
+fan_below_layer_time = 30
+slowdown_below_layer_time = 15
+min_print_speed = 15
+fan_always_on = 1
+cooling = 1
+filament_max_volumetric_speed = 1.2
+filament_notes = "Material Description\nTPC 45D is a flexible, shore 45D, rubber-like Thermoplastic Copolyester Elastomer (TPE-C), which is derived from rapeseed oil and combines the best properties of elastomers (rubbers) and polyesters. The material delivers excellent adhesion in the Z-direction, meaning that the printed layers do not detach - even with extreme deformation.\n\nPrinting Recommendations:\nApply Magigoo Flex to a clean build plate to improve adhesion."
+
+[filament:Ultrafuse TPU-64D]
+inherits = Ultrafuse TPC-45D
+filament_density = 1.16
+first_layer_temperature = 230
+temperature = 225
+first_layer_bed_temperature = 40
+bed_temperature = 40
+min_fan_speed = 20
+max_fan_speed = 100
+filament_notes = "Material Description\nUltrafuse® TPU 64D is the hardest elastomer in BASF Forward AM’s flexible productline. The material shows a relatively high rigidity while maintaining a certain flexibility. This filament is the perfect match for industrial applications requiring rigid parts being resistant to impact, wear and tear. Due to its property profile, the material can be used as an alternative for parts made from ABS and rubbers. Ultrafuse® TPU 64D is easy to print on direct drive and bowden style printers and is compatible with soluble BVOH support to realize the most complex geometries.\n\nPrinting Recommendations:\nUltrafuse TPU can be printed directly onto a clean build plate. A small amount of 3Dlac can make removal easier after printing."
+
+[filament:Ultrafuse TPU-85A]
+inherits = Ultrafuse TPU-64D
+filament_density = 1.11
+first_layer_temperature = 225
+temperature = 220
+filament_notes = "Material Description\nUltrafuse® TPU 85A comes in its natural white color. Chemical properties (e.g. resistance against particular substances) and tolerance for solvents can be made available, if these factors are relevant for a specific application. Generally, these properties correspond to publicly available data on polyether based TPUs. This material is not FDA conform. Good flexibility at low temperature, good wear performance and good damping behavior are the key features of Ultrafuse® TPU 85A.\n\nPrinting Recommendations:\nUltrafuse TPU can be printed directly onto a clean build plate. A small amount of 3Dlac can make removal easier after printing."
+
+[filament:Ultrafuse TPU-95A]
+inherits = Ultrafuse TPU-85A
+filament_density = 1.14
+first_layer_temperature = 230
+temperature = 225
+filament_notes = "Material Description\nUltrafuse® TPU 95A comes with a well-balanced profile of flexibility and durability. On top of that, it allows for easier and faster printing then softer TPU grades. Parts printed with Ultrafuse® TPU 95A show a high elongation, good impact resistance, excellent layer adhesion and a good resistance to oils and common industrially used chemicals. Due to its good printing behavior, Ultrafuse® TPU 95A is a good choice for starting printing flexible materials on both direct drive and bowden style printers.\n\nPrinting Recommendations:\nUltrafuse TPU can be printed directly onto a clean build plate. A small amount of 3Dlac can make removal easier after printing."
+
+[filament:Ultrafuse rPET]
+inherits = Ultrafuse PET
+filament_density = 1.27
+filament_colour = #9DC5FF
+first_layer_temperature = 235
+temperature = 235
+first_layer_bed_temperature = 80
+bed_temperature = 75
+min_fan_speed = 50
+max_fan_speed = 100
+fan_below_layer_time = 15
+filament_notes = "Material Description\nPET is mainly known by the well-known PET bottle material. This recycled has a natural transparent blueish look. It has excellent 3D printing properties and good mechanical characteristics."
+
+[filament:Ultrafuse Metal]
+inherits = *ABSC*
+filament_vendor = BASF
+filament_density = 4.5
+extrusion_multiplier = 1.08
+first_layer_temperature = 250
+first_layer_bed_temperature = 100
+temperature = 250
+bed_temperature = 100
+min_fan_speed = 0
+max_fan_speed = 0
+bridge_fan_speed = 0
+cooling = 0
+fan_always_on = 0
+filament_max_volumetric_speed = 4
+filament_type = METAL
+filament_colour = #FFFFFF
+
+[filament:Polymaker PC-Max]
+inherits = *ABS*
+filament_vendor = Polymaker
+filament_cost = 77.3
+filament_density = 1.20
+filament_type = PC
+bed_temperature = 115
+filament_colour = #FFF2EC
+first_layer_bed_temperature = 100
+first_layer_temperature = 270
+temperature = 270
+bridge_fan_speed = 0
+
+[filament:PrimaSelect PVA+]
+inherits = *PLA*
+filament_vendor = PrimaSelect
+filament_cost = 122.1
+filament_density = 1.23
+cooling = 0
+fan_always_on = 0
+filament_colour = #FFFFD7
+filament_soluble = 1
+filament_type = PVA
+first_layer_temperature = 195
+temperature = 195
+
+[filament:Prusa ABS]
+inherits = *ABSC*
+filament_vendor = Made for Prusa
+filament_cost = 27.82
+filament_density = 1.08
+filament_spool_weight = 230
+
+[filament:Prusa HIPS]
+inherits = Generic HIPS
+filament_vendor = Made for Prusa
+first_layer_temperature = 220
+temperature = 220
+
+[filament:Generic HIPS]
+inherits = *ABS*
+filament_vendor = Generic
+filament_cost = 27.3
+filament_density = 1.04
+bridge_fan_speed = 50
+cooling = 1
+extrusion_multiplier = 1
+fan_always_on = 1
+fan_below_layer_time = 10
+filament_colour = #FFFFD7
+filament_soluble = 1
+filament_type = HIPS
+first_layer_temperature = 230
+max_fan_speed = 20
+min_fan_speed = 20
+temperature = 230
+
+[filament:Prusa PETG]
+inherits = *PET*
+filament_vendor = Made for Prusa
+filament_cost = 27.82
+filament_density = 1.27
+filament_spool_weight = 230
+
+[filament:Verbatim PETG]
+inherits = *PET*
+filament_vendor = Verbatim
+filament_cost = 27.90
+filament_density = 1.27
+filament_spool_weight = 235
+
+[filament:Prusament PETG]
+inherits = *PET*
+filament_vendor = Prusa Polymers
+first_layer_temperature = 240
+temperature = 250
+filament_cost = 36.29
+filament_density = 1.27
+filament_spool_weight = 201
+filament_type = PETG
+
+[filament:Prusament PETG Carbon Fiber]
+inherits = Prusament PETG
+filament_vendor = Prusa Polymers
+first_layer_temperature = 260
+temperature = 265
+extrusion_multiplier = 1.03
+filament_cost = 54.99
+filament_density = 1.27
+filament_colour = #BBBBBB
+
+[filament:Prusament PETG V0]
+inherits = Prusament PETG
+first_layer_temperature = 230
+temperature = 230
+filament_cost = 54.99
+filament_density = 1.27
+extrusion_multiplier = 1.04
+filament_colour = #BBBBBB
+
+[filament:Prusa PLA]
+inherits = *PLA*
+filament_vendor = Made for Prusa
+filament_cost = 27.82
+filament_density = 1.24
+filament_spool_weight = 230
+
+[filament:Eolas Prints PLA]
+inherits = *PLA*
+filament_vendor = Eolas Prints
+filament_cost = 23.50
+filament_density = 1.24
+filament_spool_weight = 0
+filament_colour = #4D9398
+temperature = 208
+
+[filament:Eolas Prints PLA Matte]
+inherits = Eolas Prints PLA
+filament_cost = 25.50
+temperature = 212
+
+[filament:Eolas Prints INGEO 850]
+inherits = Eolas Prints PLA
+filament_cost = 25.90
+temperature = 210
+
+[filament:Eolas Prints INGEO 870]
+inherits = Eolas Prints PLA
+filament_cost = 25.90
+temperature = 215
+first_layer_bed_temperature = 68
+first_layer_temperature = 220
+bed_temperature = 65
+
+[filament:Eolas Prints PETG]
+inherits = *PET*
+filament_vendor = Eolas Prints
+filament_cost = 29.90
+filament_density = 1.27
+filament_spool_weight = 0
+filament_colour = #4D9398
+temperature = 240
+first_layer_bed_temperature = 85
+first_layer_temperature = 235
+bed_temperature = 90
+
+[filament:Eolas Prints PETG - UV Resistant]
+inherits = Eolas Prints PETG
+filament_cost = 35.90
+temperature = 237
+first_layer_temperature = 232
+
+[filament:Eolas Prints TPU 93A]
+inherits = *FLEX*
+filament_vendor = Eolas Prints
+filament_cost = 34.99
+filament_density = 1.21
+filament_colour = #4D9398
+filament_max_volumetric_speed = 1.2
+temperature = 235
+first_layer_bed_temperature = 30
+bed_temperature = 30
+filament_retract_length = 0
+extrusion_multiplier = 1.16
+
+[filament:Fiberlogy Easy PLA]
+inherits = *PLA*
+filament_vendor = Fiberlogy
+filament_cost = 20
+filament_density = 1.24
+first_layer_temperature = 220
+temperature = 220
+filament_spool_weight = 330
+
+[filament:Fiberlogy Easy PET-G]
+inherits = *PET*
+filament_vendor = Fiberlogy
+filament_spool_weight = 330
+filament_cost = 20
+filament_density = 1.27
+first_layer_bed_temperature = 80
+bed_temperature = 80
+first_layer_temperature = 235
+temperature = 235
+min_fan_speed = 15
+max_fan_speed = 30
+bridge_fan_speed = 60
+disable_fan_first_layers = 5
+full_fan_speed_layer = 5
+slowdown_below_layer_time = 15
+
+[filament:Fiberlogy ASA]
+inherits = *ABS*
+filament_vendor = Fiberlogy
+filament_cost = 33
+filament_density = 1.07
+filament_spool_weight = 330
+fan_always_on = 0
+cooling = 1
+min_fan_speed = 10
+max_fan_speed = 15
+bridge_fan_speed = 30
+min_print_speed = 15
+slowdown_below_layer_time = 15
+first_layer_temperature = 260
+temperature = 260
+first_layer_bed_temperature = 100
+bed_temperature = 100
+filament_type = ASA
+fan_below_layer_time = 30
+disable_fan_first_layers = 5
+
+[filament:Fiberlogy Easy ABS]
+inherits = Fiberlogy ASA
+filament_cost = 22.67
+filament_density = 1.09
+fan_always_on = 0
+cooling = 1
+min_fan_speed = 10
+max_fan_speed = 15
+min_print_speed = 15
+slowdown_below_layer_time = 15
+first_layer_temperature = 250
+temperature = 250
+first_layer_bed_temperature = 100
+bed_temperature = 100
+filament_type = ABS
+fan_below_layer_time = 25
+disable_fan_first_layers = 5
+
+[filament:Fiberlogy CPE HT]
+inherits = *PET*
+filament_vendor = Fiberlogy
+filament_cost = 42.67
+filament_density = 1.18
+extrusion_multiplier = 0.98
+filament_spool_weight = 330
+fan_always_on = 1
+cooling = 1
+min_fan_speed = 0
+max_fan_speed = 0
+bridge_fan_speed = 50
+min_print_speed = 15
+first_layer_temperature = 275
+temperature = 275
+first_layer_bed_temperature = 105
+bed_temperature = 105
+filament_type = CPE
+fan_below_layer_time = 20
+slowdown_below_layer_time = 15
+disable_fan_first_layers = 5
+
+[filament:Fiberlogy PCTG]
+inherits = Fiberlogy CPE HT
+filament_cost = 29.41
+filament_density = 1.23
+extrusion_multiplier = 1
+min_fan_speed = 10
+max_fan_speed = 15
+first_layer_temperature = 265
+temperature = 265
+first_layer_bed_temperature = 90
+bed_temperature = 90
+filament_type = PCTG
+
+[filament:Fiberlogy FiberFlex 40D]
+inherits = *FLEX*
+filament_vendor = Fiberlogy
+fan_always_on = 1
+filament_max_volumetric_speed = 1.5
+extrusion_multiplier = 1.12
+first_layer_temperature = 230
+first_layer_bed_temperature = 60
+temperature = 230
+bed_temperature = 60
+bridge_fan_speed = 75
+min_fan_speed = 25
+max_fan_speed = 75
+filament_cost = 39.41
+filament_density = 1.16
+disable_fan_first_layers = 5
+full_fan_speed_layer = 5
+min_print_speed = 15
+cooling = 1
+filament_spool_weight = 330
+
+[filament:Fiberlogy MattFlex 40D]
+inherits = Fiberlogy FiberFlex 40D
+filament_vendor = Fiberlogy
+fan_always_on = 1
+filament_max_volumetric_speed = 1.35
+extrusion_multiplier = 1.1
+filament_cost = 49.11
+
+[filament:Fiberlogy FiberFlex 30D]
+inherits = Fiberlogy FiberFlex 40D
+filament_max_volumetric_speed = 1.2
+extrusion_multiplier = 1.15
+first_layer_temperature = 240
+temperature = 240
+min_fan_speed = 25
+max_fan_speed = 60
+filament_density = 1.07
+
+[filament:Fiberlogy FiberSatin]
+inherits = Fiberlogy Easy PLA
+first_layer_temperature = 215
+temperature = 215
+extrusion_multiplier = 1
+filament_density = 1.2
+filament_cost = 32.35
+
+[filament:Fiberlogy FiberSilk]
+inherits = Fiberlogy FiberSatin
+first_layer_temperature = 230
+temperature = 230
+extrusion_multiplier = 0.97
+filament_density = 1.22
+filament_cost = 32.35
+
+[filament:Fiberlogy FiberWood]
+inherits = Fiberlogy Easy PLA
+first_layer_temperature = 185
+temperature = 185
+extrusion_multiplier = 1
+filament_density = 1.23
+filament_cost = 38.66
+
+[filament:Fiberlogy HD PLA]
+inherits = Fiberlogy Easy PLA
+first_layer_temperature = 230
+temperature = 230
+extrusion_multiplier = 1
+filament_density = 1.24
+filament_cost = 30.59
+
+[filament:Fiberlogy PLA Mineral]
+inherits = Fiberlogy Easy PLA
+first_layer_temperature = 195
+temperature = 190
+extrusion_multiplier = 0.98
+filament_density = 1.38
+filament_cost = 37.64
+
+[filament:Fiberlogy Impact PLA]
+inherits = Fiberlogy HD PLA
+filament_density = 1.22
+filament_cost = 27.65
+
+[filament:Fiberlogy Nylon PA12]
+inherits = Fiberlogy ASA
+filament_type = PA
+filament_density = 1.01
+filament_cost = 48
+first_layer_bed_temperature = 105
+bed_temperature = 105
+first_layer_temperature = 265
+temperature = 265
+min_fan_speed = 10
+max_fan_speed = 15
+fan_below_layer_time = 20
+bridge_fan_speed = 30
+fan_always_on = 0
+
+[filament:Fiberlogy Nylon PA12+CF15]
+inherits = Fiberlogy Nylon PA12
+extrusion_multiplier = 0.97
+filament_density = 1.07
+filament_cost = 87.5
+first_layer_bed_temperature = 105
+bed_temperature = 105
+first_layer_temperature = 265
+temperature = 265
+min_fan_speed = 10
+max_fan_speed = 15
+fan_below_layer_time = 20
+bridge_fan_speed = 30
+fan_always_on = 0
+
+[filament:Fiberlogy Nylon PA12+GF15]
+inherits = Fiberlogy Nylon PA12+CF15
+filament_density = 1.13
+
+[filament:Fiberlogy PP]
+inherits = *ABS*
+filament_vendor = Fiberlogy
+filament_cost = 36.67
+filament_density = 1.05
+extrusion_multiplier = 1.05
+filament_spool_weight = 330
+fan_always_on = 1
+cooling = 1
+min_fan_speed = 0
+max_fan_speed = 25
+bridge_fan_speed = 70
+min_print_speed = 15
+slowdown_below_layer_time = 15
+first_layer_temperature = 245
+temperature = 245
+first_layer_bed_temperature = 0
+bed_temperature = 0
+filament_type = PP
+fan_below_layer_time = 100
+disable_fan_first_layers = 5
+filament_max_volumetric_speed = 5
+
+[filament:Filament PM PLA]
+inherits = *PLA*
+filament_vendor = Filament PM
+filament_cost = 27.82
+filament_density = 1.24
+filament_spool_weight = 230
+
+[filament:Filament PM PLA+]
+inherits = *PLA*
+filament_vendor = Filament PM
+filament_cost = 27.82
+filament_density = 1.25
+filament_spool_weight = 0
+min_fan_speed = 50
+max_fan_speed = 70
+fan_below_layer_time = 100
+slowdown_below_layer_time = 20
+
+[filament:Filament PM ASA]
+inherits = Fillamentum ASA
+filament_vendor = Filament PM
+filament_cost = 27.82
+filament_density = 1.07
+filament_spool_weight = 0
+first_layer_temperature = 255
+temperature = 255
+first_layer_bed_temperature = 100
+bed_temperature = 100
+min_fan_speed = 15
+max_fan_speed = 15
+
+[filament:Filament PM CFJet]
+inherits = *PET*
+filament_vendor = Filament PM
+filament_colour = #BBBBBB
+filament_cost = 27.82
+filament_density = 1.27
+first_layer_temperature = 245
+temperature = 255
+
+[filament:Filament PM PAJet]
+inherits = *PET*
+filament_vendor = Filament PM
+filament_colour = #ECFAFF
+filament_cost = 27.82
+filament_density = 1.01
+first_layer_temperature = 245
+temperature = 245
+first_layer_bed_temperature = 100
+bed_temperature = 100
+extrusion_multiplier = 1.1
+fan_always_on = 0
+cooling = 0
+min_fan_speed = 0
+max_fan_speed = 0
+bridge_fan_speed = 0
+filament_type = PA
+
+[filament:Filament PM PA-CFJet]
+inherits = *PET*
+filament_vendor = Filament PM
+filament_colour = #BBBBBB
+filament_cost = 27.82
+filament_density = 1.01
+first_layer_temperature = 245
+temperature = 245
+first_layer_bed_temperature = 100
+bed_temperature = 100
+extrusion_multiplier = 1.02
+fan_always_on = 0
+cooling = 0
+min_fan_speed = 0
+max_fan_speed = 0
+bridge_fan_speed = 0
+filament_type = PA
+
+[filament:Filament PM FRJet]
+inherits = *PET*
+filament_vendor = Filament PM
+filament_colour = #BBBBBB
+filament_cost = 27.82
+filament_density = 1.27
+first_layer_temperature = 240
+temperature = 240
+extrusion_multiplier = 0.95
+fan_always_on = 0
+cooling = 0
+min_fan_speed = 5
+max_fan_speed = 15
+bridge_fan_speed = 15
+
+[filament:Filament PM PC-ABS]
+inherits = *ABSC*
+filament_vendor = Filament PM
+filament_colour = #DEE0E6
+filament_cost = 49.90
+filament_density = 1.19
+first_layer_temperature = 275
+temperature = 275
+first_layer_bed_temperature = 100
+bed_temperature = 100
+fan_always_on = 0
+cooling = 0
+min_fan_speed = 20
+max_fan_speed = 20
+bridge_fan_speed = 30
+filament_type = PC
+
+[filament:Filament PM PPJet]
+inherits = *FLEX*
+filament_vendor = Filament PM
+filament_colour = #ECFAFF
+filament_cost = 33.99
+filament_density = 0.89
+first_layer_temperature = 235
+temperature = 230
+first_layer_bed_temperature = 100
+bed_temperature = 100
+fan_always_on = 1
+cooling = 1
+extrusion_multiplier = 1.15
+min_fan_speed = 20
+max_fan_speed = 40
+bridge_fan_speed = 80
+filament_type = PP
+disable_fan_first_layers = 3
+slowdown_below_layer_time = 20
+
+[filament:Filament PM TPE88 RubberJet]
+inherits = *FLEX*
+filament_vendor = Filament PM
+filament_cost = 33.99
+filament_density = 0.89
+first_layer_temperature = 240
+temperature = 240
+first_layer_bed_temperature = 0
+bed_temperature = 0
+fan_always_on = 1
+cooling = 0
+extrusion_multiplier = 1.14
+min_fan_speed = 10
+max_fan_speed = 10
+bridge_fan_speed = 30
+filament_type = FLEX
+disable_fan_first_layers = 3
+slowdown_below_layer_time = 20
+filament_diameter = 1.68
+
+[filament:AmazonBasics PLA]
+inherits = *PLA*
+filament_vendor = AmazonBasics
+filament_cost = 25.4
+filament_density = 1.24
+
+[filament:Overture PLA]
+inherits = *PLA*
+filament_vendor = Overture
+filament_cost = 22
+filament_density = 1.24
+filament_spool_weight = 235
+
+[filament:Overture PETG]
+inherits = *PET*
+filament_vendor = Overture
+filament_cost = 25
+filament_spool_weight = 155
+filament_density = 1.25
+first_layer_temperature = 250
+first_layer_bed_temperature = 85
+temperature = 250
+bed_temperature = 90
+
+[filament:Hatchbox PLA]
+inherits = *PLA*
+filament_vendor = Hatchbox
+filament_cost = 25.4
+filament_density = 1.27
+filament_spool_weight = 245
+
+[filament:Esun PLA]
+inherits = *PLA*
+filament_vendor = Esun
+filament_cost = 25.4
+filament_density = 1.24
+filament_spool_weight = 265
+
+[filament:Das Filament PLA]
+inherits = *PLA*
+filament_vendor = Das Filament
+filament_cost = 25.4
+filament_density = 1.24
+
+[filament:EUMAKERS PLA]
+inherits = *PLA*
+filament_vendor = EUMAKERS
+filament_cost = 25.4
+filament_density = 1.24
+
+[filament:Floreon3D PLA]
+inherits = *PLA*
+filament_vendor = Floreon3D
+filament_cost = 25.4
+filament_density = 1.24
+
+[filament:Prusament PLA]
+inherits = *PLA*
+filament_vendor = Prusa Polymers
+temperature = 215
+filament_cost = 36.29
+filament_density = 1.24
+filament_spool_weight = 201
+filament_notes = "Affordable filament for everyday printing in premium quality manufactured in-house by Josef Prusa"
+
+[filament:Prusament PVB]
+inherits = *PLA*
+filament_vendor = Prusa Polymers
+temperature = 215
+bed_temperature = 75
+first_layer_bed_temperature = 75
+filament_cost = 60.48
+filament_density = 1.09
+filament_spool_weight = 201
+filament_max_volumetric_speed = 8
+filament_type = PVB
+filament_soluble = 1
+filament_colour = #FFFF6F
+slowdown_below_layer_time = 20
+
+[filament:Fillamentum Flexfill 98A]
+inherits = *FLEX*
+filament_vendor = Fillamentum
+filament_cost = 82.26
+filament_density = 1.23
+filament_spool_weight = 230
+extrusion_multiplier = 1.1
+filament_max_volumetric_speed = 1.5
+fan_always_on = 1
+cooling = 0
+max_fan_speed = 60
+min_fan_speed = 60
+disable_fan_first_layers = 4
+full_fan_speed_layer = 6
+
+[filament:ColorFabb VarioShore TPU]
+inherits = Fillamentum Flexfill 98A
+filament_vendor = ColorFabb
+filament_colour = #BBBBBB
+filament_cost = 71.35
+filament_density = 1.22
+filament_spool_weight = 0
+extrusion_multiplier = 0.85
+first_layer_temperature = 220
+temperature = 220
+
+[filament:Taulman Bridge]
+inherits = *common*
+filament_vendor = Taulman
+filament_cost = 40
+filament_density = 1.13
+bed_temperature = 110
+bridge_fan_speed = 40
+cooling = 0
+disable_fan_first_layers = 3
+fan_always_on = 0
+fan_below_layer_time = 20
+filament_colour = #DEE0E6
+filament_soluble = 0
+filament_type = PA
+first_layer_bed_temperature = 90
+first_layer_temperature = 260
+temperature = 260
+max_fan_speed = 0
+min_fan_speed = 0
+filament_max_volumetric_speed = 6
+
+[filament:Fillamentum Nylon FX256]
+inherits = *common*
+filament_vendor = Fillamentum
+filament_cost = 56.99
+filament_density = 1.01
+filament_spool_weight = 230
+bed_temperature = 90
+bridge_fan_speed = 30
+cooling = 1
+disable_fan_first_layers = 6
+fan_always_on = 0
+fan_below_layer_time = 20
+min_print_speed = 15
+slowdown_below_layer_time = 20
+filament_colour = #DEE0E6
+filament_max_volumetric_speed = 6
+filament_soluble = 0
+filament_type = PA
+first_layer_bed_temperature = 90
+first_layer_temperature = 250
+max_fan_speed = 0
+min_fan_speed = 0
+temperature = 250
+
+[filament:Fiberthree F3 PA Pure Pro]
+inherits = *common*
+filament_vendor = Fiberthree
+filament_cost = 200.84
+filament_density = 1.2
+bed_temperature = 90
+first_layer_bed_temperature = 90
+first_layer_temperature = 285
+temperature = 285
+bridge_fan_speed = 30
+cooling = 1
+disable_fan_first_layers = 3
+fan_always_on = 1
+fan_below_layer_time = 20
+min_print_speed = 15
+slowdown_below_layer_time = 10
+filament_colour = #DEE0E6
+filament_max_volumetric_speed = 5
+filament_soluble = 0
+filament_type = PA
+max_fan_speed = 20
+min_fan_speed = 20
+
+[filament:Fiberthree F3 PA-CF Pro]
+inherits = *common*
+filament_vendor = Fiberthree
+filament_cost = 208.1
+filament_density = 1.25
+bed_temperature = 90
+first_layer_bed_temperature = 90
+first_layer_temperature = 285
+temperature = 285
+bridge_fan_speed = 30
+cooling = 1
+disable_fan_first_layers = 3
+fan_always_on = 0
+fan_below_layer_time = 20
+min_print_speed = 15
+slowdown_below_layer_time = 10
+filament_colour = #DEE0E6
+filament_max_volumetric_speed = 5
+filament_soluble = 0
+filament_type = PA
+max_fan_speed = 0
+min_fan_speed = 0
+
+[filament:Fiberthree F3 PA-GF Pro]
+inherits = Fiberthree F3 PA-CF Pro
+filament_vendor = Fiberthree
+filament_cost = 205.68
+filament_density = 1.27
+fan_always_on = 1
+max_fan_speed = 15
+min_fan_speed = 15
+
+[filament:Fiberthree F3 PA-GF30 Pro]
+inherits = Prusament PC Blend Carbon Fiber
+filament_vendor = Fiberthree
+filament_cost = 208.01 
+filament_density = 1.35
+extrusion_multiplier = 1.03
+first_layer_temperature = 275
+temperature = 285
+first_layer_bed_temperature = 90
+bed_temperature = 90
+fan_below_layer_time = 10
+max_fan_speed = 15
+min_fan_speed = 15
+filament_type = PA
+
+[filament:Taulman T-Glase]
+inherits = *PET*
+filament_vendor = Taulman
+filament_cost = 40
+filament_density = 1.27
+bridge_fan_speed = 40
+cooling = 0
+fan_always_on = 0
+first_layer_bed_temperature = 90
+first_layer_temperature = 240
+max_fan_speed = 5
+min_fan_speed = 0
+
+[filament:Verbatim PLA]
+inherits = *PLA*
+filament_vendor = Verbatim
+filament_cost = 42.99
+filament_density = 1.24
+filament_spool_weight = 235
+
+[filament:Verbatim BVOH]
+inherits = *common*
+filament_vendor = Verbatim
+filament_cost = 193.58
+filament_density = 1.14
+filament_spool_weight = 235
+bed_temperature = 60
+bridge_fan_speed = 100
+cooling = 0
+disable_fan_first_layers = 1
+extrusion_multiplier = 1
+fan_always_on = 0
+fan_below_layer_time = 100
+filament_colour = #FFFFD7
+filament_soluble = 1
+filament_type = PVA
+first_layer_bed_temperature = 60
+first_layer_temperature = 215
+max_fan_speed = 100
+min_fan_speed = 100
+temperature = 210
+
+[filament:Verbatim PP]
+inherits = *common*
+filament_vendor = Verbatim
+filament_cost = 72
+filament_density = 0.89
+filament_spool_weight = 235
+bed_temperature = 100
+bridge_fan_speed = 100
+cooling = 1
+disable_fan_first_layers = 2
+extrusion_multiplier = 1
+fan_always_on = 1
+fan_below_layer_time = 100
+filament_colour = #DEE0E6
+filament_max_volumetric_speed = 5
+filament_type = PP
+first_layer_bed_temperature = 100
+first_layer_temperature = 220
+max_fan_speed = 100
+min_fan_speed = 100
+temperature = 220
+
+[filament:FormFutura Centaur PP]
+inherits = *common*
+filament_vendor = FormFutura
+filament_cost = 70
+filament_density = 0.89
+filament_spool_weight = 212
+bridge_fan_speed = 100
+cooling = 1
+disable_fan_first_layers = 2
+extrusion_multiplier = 1.05
+fan_always_on = 1
+fan_below_layer_time = 100
+filament_colour = #DEE0E6
+filament_max_volumetric_speed = 4
+filament_type = PP
+first_layer_bed_temperature = 85
+bed_temperature = 85
+first_layer_temperature = 235
+max_fan_speed = 70
+min_fan_speed = 70
+temperature = 235
+filament_wipe = 0
+filament_retract_lift = 0
+[filament:FilAr PLA]
+inherits = *PLA*
+filament_vendor = FilAr
+filament_type = PLA
+filament_density = 1.24
+first_layer_temperature = 215
+first_layer_bed_temperature = 60
+temperature = 210
+bed_temperature = 60
+
+[filament:FilAr PLA Mate]
+inherits = *PLA*
+filament_vendor = FilAr
+filament_type = PLA
+filament_density = 1.24
+first_layer_temperature = 205
+first_layer_bed_temperature = 60
+temperature = 200
+bed_temperature = 60
+
+[filament:FilAr PETG]
+inherits = *PET*
+filament_vendor = FilAr
+filament_type = PETG
+filament_density = 1.27
+first_layer_temperature = 245
+first_layer_bed_temperature = 78
+temperature = 240
+bed_temperature = 78

--- a/Templates/index.idx
+++ b/Templates/index.idx
@@ -1,4 +1,5 @@
 min_slic3r_version = 2.8.0-alpha0
+2.0.4 Added FilAr PLA, PLA Mate and PETG filaments.
 2.0.3 Updated 3D-Fuel filament templates.
 2.0.2 Added new templates.
 2.0.1 Added Prusament Woodfill, Prusament rPLA and VOXELPLA filaments.


### PR DESCRIPTION
Adds **FilAr**, an Argentine filament manufacturer (https://www.filar.com.ar), to the `Templates` vendor as generic, printer-agnostic filament profiles — three materials: **PLA**, **PLA Mate** and **PETG**.

### Changes
- New bundle `Templates/2.0.4.ini` (copy of `2.0.3` with `config_version = 2.0.4`) adding three `[filament:...]` sections that inherit from the existing `*PLA*` / `*PET*` base profiles, with `filament_vendor = FilAr`.
- `Templates/index.idx`: new entry `2.0.4 Added FilAr PLA, PLA Mate and PETG filaments.`

No printer models are added; the profiles inherit the generic `compatible_printers_condition` from `*common*`, so they're available on all printers (same pattern as 3D-Fuel, BASF, ColorFabb, etc.).

| Filament | inherits | Nozzle | Bed | Density |
|---|---|---|---|---|
| FilAr PLA | `*PLA*` | 210 °C (first 215) | 60 °C | 1.24 |
| FilAr PLA Mate | `*PLA*` | 200 °C (first 205) | 60 °C | 1.24 |
| FilAr PETG | `*PET*` | 240 °C (first 245) | 78 °C | 1.27 |

Diameter 1.75 mm. Values follow the manufacturer's published datasheet. These profiles are already part of OrcaSlicer's filament library (OrcaSlicer/OrcaSlicer#13977, merged).
